### PR TITLE
Update repository URLs to SciML organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # BasicStats.jl
 
-[![Build Status](https://github.com/ChrisRackauckas-Claude/BasicStats.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ChrisRackauckas-Claude/BasicStats.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/ChrisRackauckas-Claude/BasicStats.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ChrisRackauckas-Claude/BasicStats.jl)
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ChrisRackauckas-Claude.github.io/BasicStats.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ChrisRackauckas-Claude.github.io/BasicStats.jl/dev/)
+[![Build Status](https://github.com/SciML/BasicStats.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/SciML/BasicStats.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/SciML/BasicStats.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/SciML/BasicStats.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://SciML.github.io/BasicStats.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://SciML.github.io/BasicStats.jl/dev/)
 
 A lightweight Julia package providing basic statistical functions with minimal dependencies. BasicStats.jl serves as a lower-dependency alternative to Statistics.jl, implementing the same algorithms but without pulling in additional dependencies.
 
@@ -54,7 +54,7 @@ This package is ideal when you need:
 
 ## Documentation
 
-For detailed documentation, see [https://ChrisRackauckas-Claude.github.io/BasicStats.jl/stable/](https://ChrisRackauckas-Claude.github.io/BasicStats.jl/stable/)
+For detailed documentation, see [https://SciML.github.io/BasicStats.jl/stable/](https://SciML.github.io/BasicStats.jl/stable/)
 
 ## Contributing
 
@@ -68,7 +68,7 @@ If you use BasicStats.jl in your research, please cite:
 @software{BasicStats.jl,
   author = {Rackauckas, Chris and contributors},
   title = {BasicStats.jl: Lightweight Statistical Functions for Julia},
-  url = {https://github.com/ChrisRackauckas-Claude/BasicStats.jl},
+  url = {https://github.com/SciML/BasicStats.jl},
   year = {2024}
 }
 ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(;
     authors="ChrisRackauckas <contact@chrisrackauckas.com>",
     sitename="BasicStats.jl",
     format=Documenter.HTML(;
-        canonical="https://ChrisRackauckas-Claude.github.io/BasicStats.jl",
+        canonical="https://SciML.github.io/BasicStats.jl",
         edit_link="main",
         assets=String[],
     ),
@@ -19,6 +19,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/ChrisRackauckas-Claude/BasicStats.jl",
+    repo="github.com/SciML/BasicStats.jl",
     devbranch="main",
 )


### PR DESCRIPTION
This PR updates all repository URLs from the previous location to the new SciML organization location.

## Changes
- Updated badge URLs in README.md
- Updated documentation URLs in README.md  
- Updated repository URL in citation
- Updated canonical URL in docs/make.jl
- Updated deploy repository in docs/make.jl

All URLs now point to https://github.com/SciML/BasicStats.jl